### PR TITLE
Added CFLAGS for CGAL on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,10 @@ endif()
 set(CMAKE_C_FLAGS "-Wall -g")
 set(CMAKE_CXX_FLAGS "-Wall -g")
 
-if (APPLE)
+if (APPLE OR UNIX)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wsign-compare -frounding-math")
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wsign-compare -frounding-math")
-endif (APPLE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-compare -frounding-math")
+endif()
 
 set(CMAKE_C_FLAGS_DEBUG "-O")
 set(CMAKE_CXX_FLAGS_DEBUG "-O")


### PR DESCRIPTION
Fixed a minor bug in propagating CXX_FLAGS and added correct branching for Linux into the CMakeLists.txt file.

This patch fixes compilation with CGAL on Ubuntu Linux.
